### PR TITLE
グローバルstateの使用

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
-import { useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { useState } from "react";
+import { Card } from "./components/Card";
 import { ColoredMessage } from "./components/ColoredMessage";
 import { CssModules } from "./components/CssModule";
 import { Emotion } from "./components/Emotion";
+import { AdminFlagContext } from "./components/providers/AdminFlagProvider";
 import { StyledComponents } from "./components/StyledComponents";
 import { StyledJsx } from "./components/StyledJsx";
 
@@ -19,6 +21,11 @@ export const App = () => {
     alert()
   }, [num]);
 
+  // context内のisAdminと更新関数を取得
+  const { isAdmin, setIsAdmin } = useContext(AdminFlagContext);
+
+  // 切り替えボタンを押した時
+  const onClickSwitch = () => setIsAdmin(!isAdmin);
 
   return (
     <>
@@ -31,6 +38,11 @@ export const App = () => {
       <StyledJsx />
       <StyledComponents />
       <Emotion />
+      <div>
+        {isAdmin ? <span>管理者です</span> : <span>管理者以外です</span>}
+        <button onClick={onClickSwitch}>切り替え</button>
+        <Card isAdmin={isAdmin} />
+      </div>
     </>
   );
 };

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,22 @@
+import { EditButton } from "./EditButton";
+
+const style = {
+  width: "300px",
+  height: "200px",
+  margin: "8px",
+  borderRadius: "8px",
+  backgroundColor: "#e9dbd0",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center"
+};
+
+export const Card = () => {
+  return (
+    <div style={style}>
+      <p>山田太郎</p>
+      <EditButton/>
+    </div>
+  )
+}

--- a/src/components/EditButton.jsx
+++ b/src/components/EditButton.jsx
@@ -1,0 +1,20 @@
+import { useContext } from "react";
+
+// 作成したContextをimport
+import { AdminFlagContext } from "./providers/AdminFlagProvider";
+
+const style = {
+  width: "100px",
+  padding: "6px",
+  borderRadius: "8px"
+};
+
+export const EditButton = () => {
+  const { isAdmin } = useContext(AdminFlagContext);
+
+  return (
+    <button style={style} disabled={!isAdmin}>
+      編集
+    </button>
+  );
+};

--- a/src/components/providers/AdminFlagProvider.jsx
+++ b/src/components/providers/AdminFlagProvider.jsx
@@ -1,0 +1,22 @@
+import { createContext, useState } from "react" ;
+
+// AdminFlagContextという名前でContextの器を作成
+// createContextはデフォルト値も設定できる
+// Contextを参照する側のコンポーネントで使用するためexportする
+
+export const AdminFlagContext = createContext({});
+
+// Contextの値を参照できるようにするために、ProviderでContextの値を参照したいコンポーネント群を囲む
+// （多くの場合はルートコンポーネントなど）
+export const AdminFlagProvider = props => {
+  const { children } = props;
+
+  // 管理者フラグをstateで作成（オブジェクトの省略記法)
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  return (
+    <AdminFlagContext.Provider value ={{isAdmin, setIsAdmin}}>
+      {children}
+    </AdminFlagContext.Provider>
+  );
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,12 @@
 import ReactDOM from "react-dom";
 import { App } from "./App";
+import { AdminFlagProvider } from "./components/providers/AdminFlagProvider";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+
+// アプリ全体でAdminFlagContextを参照したいのでAppをProviderで囲む
+ReactDOM.render(
+  <AdminFlagProvider>
+    <App />
+  </AdminFlagProvider>,
+  document.getElementById("root")
+  );


### PR DESCRIPTION
## グローバルステート
`props`のバケツリレーを防ぐために、`props`をどのコンポーネントからでも参照できるようにする。

- React.createContextでContextの器を作成する
- 作成したContextのProviderでグローバルStateを扱いたいコンポーネントを囲む
- Stateを参照したいコンポーネントでReact.useContextを使う


